### PR TITLE
Fix PubKey extraction for P2WPKH inputs

### DIFF
--- a/internal/domain/silentscalar.go
+++ b/internal/domain/silentscalar.go
@@ -203,13 +203,13 @@ func extractPublicKeyFromInput(txIn *wire.TxIn, getPrevout func(wire.OutPoint) (
 
 	// P2WPKH
 	if len(txIn.Witness) == 2 {
-		_, err := ecdsa.ParseSignature(txIn.Witness[1])
+		_, err := ecdsa.ParseSignature(txIn.Witness[0])
 		if err == nil {
-			if len(txIn.Witness[0]) != 33 {
+			if len(txIn.Witness[1]) != 33 {
 				return nil, ErrNonStandardScript
 			}
 
-			return btcec.ParsePubKey(txIn.Witness[0])
+			return btcec.ParsePubKey(txIn.Witness[1])
 		}
 	}
 


### PR DESCRIPTION
I tried to send silent payment to silentium from native segwit address using geewallet (silent-payments-squashed branch) and silentium didn't recognize the payment. Since CakeWallet did recognize similar payment, I thought that there is a bug in silentium.

After some investigation, I came to conclusion that indices for witness elements used in `P2WPKH`case in `extractPublicKeyFromInput` are other way around (signature should be element 0 and pubkey should be element 1).

It's not trivial for me to test my assumption though since I need full Bitcoin node for that.